### PR TITLE
fix the warning about the flink

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -1,7 +1,7 @@
 import 
 {
   Container, 
-  FLink, 
+  // FLink,
   FooterCopy, 
   FooterDetails, 
   FooterLogo,


### PR DESCRIPTION
There was a warning on the CL that was complaining about referencing a component that was created but never used. I guess this is the issue causing vercel not to deploy the last pr